### PR TITLE
Updates to allow action group control

### DIFF
--- a/Source/FuelBalanceController.cs
+++ b/Source/FuelBalanceController.cs
@@ -35,7 +35,7 @@ using UnityEngine;
 namespace Tac
 {
     [KSPAddon(KSPAddon.Startup.Flight, false)]
-    class FuelBalanceController : MonoBehaviour
+    public class FuelBalanceController : MonoBehaviour
     {
         private Settings settings;
         private MainWindow mainWindow;
@@ -43,7 +43,7 @@ namespace Tac
         private HelpWindow helpWindow;
         private string configFilename;
         private ButtonWrapper button;
-        private Dictionary<string, ResourceInfo> resources;
+        public Dictionary<string, ResourceInfo> resources;
         private Vessel currentVessel;
         private int numberOfParts;
         private Vessel.Situations vesselSituation;


### PR DESCRIPTION
As per our IRC talk, this is all I need done in order to allow action groups to control the fuel balance.

Everything else I can take care of in my mod, I just need to be able to access where the current state of fuel transfore on the parts is stored, and reading your code I believe that to be FuelBalanceController.resources;
